### PR TITLE
Remove bazaar files and add a gitignore

### DIFF
--- a/.bzr-builddeb/default.conf
+++ b/.bzr-builddeb/default.conf
@@ -1,2 +1,0 @@
-[BUILDDEB]
-split = True

--- a/.gitignore
+++ b/.gitignore
@@ -1,5 +1,6 @@
 *.user
 builddir
+build/
 stage
 prime
 parts


### PR DESCRIPTION
This removes the files required by bazaar and moves the bzrignore to gitignore (with `build/` thrown in for good measure).