### PR TITLE
Enabling CI builds again - disable autopilot

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -113,7 +113,8 @@ install(FILES ${CMAKE_CURRENT_BINARY_DIR}/${DESKTOP_FILE}
 add_subdirectory(app)
 add_subdirectory(backend)
 add_subdirectory(po)
-add_subdirectory(tests)
+#Disabling autopilot tests for now due to CI issues
+#add_subdirectory(tests)
 
 # make the README files visible in qtcreator
 file(GLOB README_FILES

--- a/debian/ubuntu-clock-app-autopilot.install
+++ b/debian/ubuntu-clock-app-autopilot.install
@@ -1,1 +1,0 @@
-/usr/lib/*/dist-packages/ubuntu_clock_app/*


### PR DESCRIPTION
Unfortunately for the moment we need to remove autopilot tests from all projects since they fail with various reasons.
